### PR TITLE
feat: Add `config` flag to `check` subcommand

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,9 +28,16 @@ impl App {
     fn load_config(cli: &Cli) -> Result<Config> {
         let _span = span!(Level::DEBUG, "load_config").entered();
 
-        let config = if let Some(config_path) = &cli.config {
+        // Priority order: 1) subcommand config, 2) global config, 3) auto-discover, 4) default
+        let config = if let Some(config_path) = cli.get_check_config() {
             debug!(
-                "Loading config from specified path: {}",
+                "Loading config from subcommand-specified path: {}",
+                config_path.display()
+            );
+            Config::load_from_file(&config_path)?
+        } else if let Some(config_path) = &cli.config {
+            debug!(
+                "Loading config from global config path: {}",
                 config_path.display()
             );
             Config::load_from_file(config_path)?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,10 @@ pub enum Commands {
         /// Paths to check
         paths: Vec<PathBuf>,
 
+        /// Configuration file path
+        #[arg(short, long, value_name = "FILE")]
+        config: Option<PathBuf>,
+
         /// Output format
         #[arg(short = 'f', long, default_value = "human")]
         format: OutputFormat,
@@ -186,7 +190,14 @@ impl Cli {
         }
     }
 
-    pub fn parse_shell(shell_str: &str) -> Result<Shell, String> {
+    pub fn get_check_config(&self) -> Option<PathBuf> {
+        match &self.command {
+            Commands::Check { config, .. } => config.clone(),
+            _ => None,
+        }
+    }
+
+    pub fn parse_shell(shell_str: &str) -> std::result::Result<Shell, String> {
         let shell_lower = shell_str.to_lowercase();
         SUPPORTED_SHELLS
             .iter()
@@ -202,7 +213,7 @@ impl Cli {
             })
     }
 
-    pub fn generate_completion(shell_str: &str) -> Result<(), String> {
+    pub fn generate_completion(shell_str: &str) -> std::result::Result<(), String> {
         let shell = Self::parse_shell(shell_str)?;
         let mut cmd = Self::command();
         generate(shell, &mut cmd, "sizelint", &mut io::stdout());


### PR DESCRIPTION
Add `config` flag to `check` subcommand, making composing with other
tools easier.
