### PR TITLE
discovery: separate explicit path handling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,14 +147,6 @@ impl Cli {
         self.command.clone()
     }
 
-    pub fn get_paths(&self) -> Vec<PathBuf> {
-        match &self.command {
-            Commands::Check { paths, .. } if !paths.is_empty() => paths.clone(),
-            Commands::Check { .. } => vec![PathBuf::from(".")],
-            _ => vec![],
-        }
-    }
-
     pub fn get_format(&self) -> OutputFormat {
         match &self.command {
             Commands::Check { format, .. } => format.clone(),


### PR DESCRIPTION
Separate explicit path handling from discovery.
When explicit file paths are passed skip
file discovery and use them directly.
